### PR TITLE
Create empty buffer using string

### DIFF
--- a/lib/tcp_connector.js
+++ b/lib/tcp_connector.js
@@ -21,7 +21,7 @@ Client.prototype.request = function (line) {
       client.write(lineSend);
     });
 
-    var buffer = new Buffer(0, 'utf-8');
+    var buffer = new Buffer('', 'utf-8');
 
     client.on('data', function (data) {
       buffer = Buffer.concat([buffer, new Buffer(data, 'utf-8')]);


### PR DESCRIPTION
This prevents the buffer construct from failing.

```
Unhandled rejection Error: If encoding is specified then the first argument must be a string
    at new Buffer (buffer.js:74:13)
    at /home/dries/Projects/local/NoUseFreak/niko/node_modules/niko-home-control/lib/tcp_connector.js:25:18
    at Promise._execute (/home/dries/Projects/local/NoUseFreak/niko/node_modules/bluebird/js/release/debuggability.js:272:9)
    at Promise._resolveFromExecutor (/home/dries/Projects/local/NoUseFreak/niko/node_modules/bluebird/js/release/promise.js:475:18)
    at new Promise (/home/dries/Projects/local/NoUseFreak/niko/node_modules/bluebird/js/release/promise.js:77:14)
    at Client.request (/home/dries/Projects/local/NoUseFreak/niko/node_modules/niko-home-control/lib/tcp_connector.js:16:10)
    at command (/home/dries/Projects/local/NoUseFreak/niko/node_modules/niko-home-control/index.js:27:20)
    at Object.listLocations (/home/dries/Projects/local/NoUseFreak/niko/node_modules/niko-home-control/index.js:47:10)
    at Object.<anonymous> (/home/dries/Projects/local/NoUseFreak/niko/index.js:11:4)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:394:7)

```